### PR TITLE
Add license to gemspec

### DIFF
--- a/spoon.gemspec
+++ b/spoon.gemspec
@@ -7,4 +7,5 @@ Gem::Specification.new do |s|
   s.files = `git ls-files`.lines.map(&:chomp)
   s.require_paths = ["lib"]
   s.add_dependency('ffi')
+  s.license = "Apache-2.0"
 end


### PR DESCRIPTION
As per http://guides.rubygems.org/specification-reference/#license=

Using "Apache-2.0" as the abbreviation as per http://opensource.org/licenses/alphabetical
