### PR TITLE
Fix ffi_lib missing on Windows

### DIFF
--- a/lib/spoon/windows.rb
+++ b/lib/spoon/windows.rb
@@ -17,7 +17,8 @@ require 'ffi'
 module Spoon
   P_NOWAIT = 1
   extend FFI::Library
-  
+
+  ffi_lib FFI::Library::LIBC
   attach_function :_spawnve, [:int, :string, :pointer, :pointer], :int
   attach_function :_spawnvpe, [:int, :string, :pointer, :pointer], :int
   

--- a/spoon.gemspec
+++ b/spoon.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "spoon"
-  s.version = "0.0.4"
+  s.version = "0.0.5"
   s.authors = ["Charles Oliver Nutter"]
   s.date = "2013-03-29"
   s.description = s.summary = "Spoon is an FFI binding of the posix_spawn function (and Windows equivalent), providing fork+exec functionality in a single shot."


### PR DESCRIPTION
Closes headius/spoon#17 and probably rsense/rsense#36
